### PR TITLE
header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # DTL
+
 ![build](https://github.com/DU-Scholar/DTL/workflows/Nuxtjs%20with%20versioned%20node/badge.svg)
 
-DTL サークル紹介APP
+DTL サークル紹介 APP
 
 ## Netlify
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/4b0e487b-6c0a-4730-9a22-1a0703f8c36b/deploy-status)](https://app.netlify.com/sites/du-dtl/deploys)
 
 https://du-dtl.netlify.app
-
 
 ## Build Setup
 

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="c-header">
     <div class="logo-wrapper">
-      <h1 class="text_header--active">DTL<br />NAVI</h1>
+      <h1 class="text_header--active">DTL <br class="on_sp" />NAVI</h1>
       <img src="../assets/images/headerImage.png" />
     </div>
     <div class="header-list-wrapper">
@@ -20,13 +20,16 @@ export default {}
 div.c-header {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-around;
   div.logo-wrapper {
     display: flex;
     flex-direction: row;
     h1 {
       font-size: 50px;
       margin-left: 20px;
+      br.on_sp {
+        display: none;
+      }
     }
     img {
       height: 70px;
@@ -43,13 +46,35 @@ div.c-header {
       margin: 0;
       height: 100%;
       li {
-        margin: 0px 15px;
+        margin: auto 15px;
         a {
           text-decoration: none;
           &:hover {
             color: #2f5597;
           }
         }
+      }
+    }
+  }
+}
+@media screen and (max-width: 480px) {
+  div.c-header {
+    div.logo-wrapper {
+      h1 {
+        font-size: 30px;
+        br.on_sp {
+          display: block;
+        }
+      }
+      img {
+        height: 50px;
+        margin-left: 0px;
+      }
+    }
+    div.header-list-wrapper {
+      margin-right: 10px;
+      ul.header-list {
+        flex-direction: column;
       }
     }
   }


### PR DESCRIPTION
スマホでは1行にするとロゴが小さくなりすぎるから、
pc→1行
sp→2行（文字小さめ、テニスラケット小さめ）
にした。

右のリストは、小さい画面で幅落ちしないように、
pc→row
sp→column
にした。